### PR TITLE
Bump lxml version

### DIFF
--- a/custom_components/mindergas/manifest.json
+++ b/custom_components/mindergas/manifest.json
@@ -3,7 +3,7 @@
   "name": "mindergas",
   "documentation": "https://www.example.com",
   "requirements": [
-    "lxml==4.6.3",
+    "lxml==4.6.4",
     "bs4==0.0.1"
   ],
   "dependencies": [],


### PR DESCRIPTION
Needed to bump this for LinuxServer.io HA Docker image running the November HA release